### PR TITLE
fix ~MessageByName macro

### DIFF
--- a/Locator.Macs.S
+++ b/Locator.Macs.S
@@ -107,7 +107,6 @@ _SetDefaultTPT MAC
 ~MessageByName MAC
  PHS 2
  PHWL ]1;]2
- PxW ]3;]4
 _MessageByName MAC
  Tool $1701
  <<<


### PR DESCRIPTION
Should have LongWord result, Word + LongWord parameters.

See TBR #3, page 51-13