### PR TITLE
Fix case on _StartUpTools/_ShutDownTools

### DIFF
--- a/Locator.Macs.S
+++ b/Locator.Macs.S
@@ -110,16 +110,16 @@ _SetDefaultTPT MAC
 _MessageByName MAC
  Tool $1701
  <<<
-~StartupTools MAC
+~StartUpTools MAC
  PHS 2
  PxW ]1;]2
  PHL ]3
-_StartupTools MAC
+_StartUpTools MAC
  Tool $1801
  <<<
-~ShutdownTools MAC
+~ShutDownTools MAC
  PHWL ]1;]2
-_ShutdownTools MAC
+_ShutDownTools MAC
  Tool $1901
  <<<
 ~GetMsgHandle MAC


### PR DESCRIPTION
The official names from TB Ref 3 and Apple's APW macros have upper case Up and Down